### PR TITLE
Create geolocation-enabled weather app

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,24 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2020: true,
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  plugins: ['react', 'react-hooks'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
+    'react-hooks/rules-of-hooks': 'error',
+    'react-hooks/exhaustive-deps': 'warn',
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.vite
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.DS_Store
+dist
+.eslintcache

--- a/README.md
+++ b/README.md
@@ -1,27 +1,39 @@
 # Weather App
 
 ## Overview
-The Weather App is a simple application that allows users to check the current weather conditions for any location. It provides real-time weather updates and forecasts, making it easy for users to plan their day.
+The Weather App is a React single-page application that lets users check the
+latest weather conditions. On load the app attempts to detect the user's
+location via the browser geolocation API and automatically displays the current
+conditions. Users can also search for any city to view its temperature,
+conditions, and wind speed provided by the free Open-Meteo APIs.
+
+## Tech Stack
+- [React 18](https://react.dev/) for the UI
+- [Vite](https://vitejs.dev/) for the build tooling and dev server
+- [Open-Meteo](https://open-meteo.com/) for geocoding and weather data (no API key required)
 
 ## Setup Instructions
 To set up the Weather App locally, follow these steps:
 
-1. Clone the repository:
-   ```bash
-   git clone https://github.com/akaragouni/weather-app.git
-   ```
-2. Navigate to the project directory:
-   ```bash
-   cd weather-app
-   ```
-3. Install the required dependencies:
+1. Install the dependencies:
    ```bash
    npm install
    ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Open your browser and navigate to the printed local URL (default
+   `http://localhost:5173`). Allow location access when prompted to see the
+   weather for your current location.
 
-## Usage Details
-To start the application, run:
-```bash
-npm start
-```
-Open your browser and navigate to `http://localhost:3000` to view the app. Enter a location to see the current weather conditions and forecast.
+## Available Scripts
+- `npm run dev` – Start the Vite development server with hot module replacement.
+- `npm run build` – Build the app for production.
+- `npm run preview` – Preview the production build locally.
+- `npm run lint` – Run ESLint against the source files.
+
+## Environment Notes
+The app uses the browser's `navigator.geolocation` API. If permission is denied
+or the feature is unavailable, the app falls back to showing the weather for New
+York City and allows searching for other cities via the search field.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Weather App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "weather-app",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint src --ext js,jsx"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "prop-types": "^15.8.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react": "^7.34.1",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,155 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #1f2933;
+  background-color: #f4f7fb;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #e0f2ff 0%, #f4f7fb 100%);
+}
+
+.app {
+  max-width: 720px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app__header {
+  text-align: center;
+}
+
+.app__header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2.25rem;
+}
+
+.app__header p {
+  margin: 0;
+  color: #52606d;
+}
+
+.app__form {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.app__input {
+  flex: 1 1 240px;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: 1px solid #cbd2d9;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app__input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.25);
+}
+
+.app__button {
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #2563eb, #3b82f6);
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app__button:disabled {
+  cursor: progress;
+  opacity: 0.75;
+}
+
+.app__button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+}
+
+.app__error {
+  color: #b91c1c;
+  background-color: #fee2e2;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  text-align: center;
+}
+
+.app__placeholder {
+  text-align: center;
+  color: #52606d;
+}
+
+.weather-card {
+  background: rgba(255, 255, 255, 0.85);
+  border-radius: 1.5rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+}
+
+.weather-card__location {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.weather-card__updated {
+  margin: 0;
+  color: #52606d;
+}
+
+.weather-card__details {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+
+.weather-card__temperature {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.weather-card__value {
+  font-size: 3.5rem;
+  font-weight: 700;
+}
+
+.weather-card__unit {
+  font-size: 1.25rem;
+  color: #52606d;
+}
+
+.weather-card__meta {
+  color: #364152;
+  font-size: 1rem;
+}
+
+@media (max-width: 600px) {
+  .app {
+    padding-top: 1.5rem;
+  }
+
+  .weather-card__value {
+    font-size: 3rem;
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,164 @@
+import { useEffect, useMemo, useState } from 'react';
+import WeatherCard from './components/WeatherCard.jsx';
+
+const DEFAULT_CITY = 'New York';
+
+const formatError = (message) => `Oops! ${message}`;
+
+const buildGeocodingUrl = (query) =>
+  `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(
+    query,
+  )}&count=1&language=en&format=json`;
+
+const buildWeatherUrl = (latitude, longitude) =>
+  `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current_weather=true`;
+
+function App() {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [locationLabel, setLocationLabel] = useState('');
+  const [weather, setWeather] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const hasWeather = useMemo(() => Boolean(weather), [weather]);
+
+  useEffect(() => {
+    const locate = () => {
+      if (!('geolocation' in navigator)) {
+        setError(formatError('Geolocation is not supported by your browser.'));
+        fetchWeatherForCity(DEFAULT_CITY, { preserveError: true });
+        return;
+      }
+
+      setLoading(true);
+      navigator.geolocation.getCurrentPosition(
+        (position) => {
+          const { latitude, longitude } = position.coords;
+          fetchWeatherForCoords(latitude, longitude, 'Your location');
+        },
+        () => {
+          setError(
+            formatError(
+              'We could not determine your location. Showing the default city instead.',
+            ),
+          );
+          fetchWeatherForCity(DEFAULT_CITY, { preserveError: true });
+        },
+        { timeout: 10000 },
+      );
+    };
+
+    locate();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const fetchWeatherForCoords = async (
+    latitude,
+    longitude,
+    label,
+    options = {},
+  ) => {
+    const { preserveError = false } = options;
+    setLoading(true);
+    if (!preserveError) {
+      setError('');
+    }
+    try {
+      const response = await fetch(buildWeatherUrl(latitude, longitude));
+      if (!response.ok) {
+        throw new Error('Failed to fetch current weather data.');
+      }
+
+      const data = await response.json();
+      if (!data?.current_weather) {
+        throw new Error('Weather data is unavailable for this location.');
+      }
+
+      setWeather({
+        temperature: data.current_weather.temperature,
+        windspeed: data.current_weather.windspeed,
+        weathercode: data.current_weather.weathercode,
+        time: data.current_weather.time,
+      });
+      setLocationLabel(label);
+    } catch (err) {
+      setError(formatError(err.message));
+      setWeather(null);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const fetchWeatherForCity = async (city, options = {}) => {
+    const { preserveError = false } = options;
+    setLoading(true);
+    if (!preserveError) {
+      setError('');
+    }
+    try {
+      const response = await fetch(buildGeocodingUrl(city));
+      if (!response.ok) {
+        throw new Error('Failed to find the requested city.');
+      }
+
+      const data = await response.json();
+      const result = data?.results?.[0];
+      if (!result) {
+        throw new Error('No matching city found.');
+      }
+
+      await fetchWeatherForCoords(result.latitude, result.longitude, result.name, {
+        preserveError,
+      });
+    } catch (err) {
+      setError(formatError(err.message));
+      setWeather(null);
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!searchTerm.trim()) {
+      return;
+    }
+
+    fetchWeatherForCity(searchTerm.trim());
+    setSearchTerm('');
+  };
+
+  return (
+    <div className="app">
+      <header className="app__header">
+        <h1>Weather App</h1>
+        <p>Check the latest weather using your location or a city search.</p>
+      </header>
+
+      <form className="app__form" onSubmit={handleSubmit}>
+        <input
+          aria-label="City name"
+          className="app__input"
+          onChange={(event) => setSearchTerm(event.target.value)}
+          placeholder="Search for a city"
+          type="search"
+          value={searchTerm}
+        />
+        <button className="app__button" type="submit" disabled={loading}>
+          {loading ? 'Loading…' : 'Search'}
+        </button>
+      </form>
+
+      {error && <p className="app__error" role="alert">{error}</p>}
+
+      {hasWeather && (
+        <WeatherCard locationLabel={locationLabel} weather={weather} />
+      )}
+
+      {!hasWeather && !loading && !error && (
+        <p className="app__placeholder">Enter a city to see the current weather.</p>
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/WeatherCard.jsx
+++ b/src/components/WeatherCard.jsx
@@ -1,0 +1,75 @@
+import PropTypes from 'prop-types';
+
+const weatherCodeDescription = {
+  0: 'Clear sky',
+  1: 'Mainly clear',
+  2: 'Partly cloudy',
+  3: 'Overcast',
+  45: 'Fog',
+  48: 'Depositing rime fog',
+  51: 'Light drizzle',
+  53: 'Moderate drizzle',
+  55: 'Dense drizzle',
+  56: 'Light freezing drizzle',
+  57: 'Dense freezing drizzle',
+  61: 'Slight rain',
+  63: 'Moderate rain',
+  65: 'Heavy rain',
+  66: 'Light freezing rain',
+  67: 'Heavy freezing rain',
+  71: 'Slight snow fall',
+  73: 'Moderate snow fall',
+  75: 'Heavy snow fall',
+  77: 'Snow grains',
+  80: 'Slight rain showers',
+  81: 'Moderate rain showers',
+  82: 'Violent rain showers',
+  85: 'Slight snow showers',
+  86: 'Heavy snow showers',
+  95: 'Thunderstorm',
+  96: 'Thunderstorm with slight hail',
+  99: 'Thunderstorm with heavy hail',
+};
+
+const formatTime = (timeString) => {
+  const formatter = new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+
+  return formatter.format(new Date(timeString));
+};
+
+function WeatherCard({ locationLabel, weather }) {
+  const { temperature, windspeed, weathercode, time } = weather;
+  const description = weatherCodeDescription[weathercode] ?? 'Unknown conditions';
+
+  return (
+    <section className="weather-card" aria-live="polite">
+      <h2 className="weather-card__location">{locationLabel}</h2>
+      <p className="weather-card__updated">Updated {formatTime(time)}</p>
+      <div className="weather-card__details">
+        <div className="weather-card__temperature">
+          <span className="weather-card__value">{temperature.toFixed(1)}</span>
+          <span className="weather-card__unit">°C</span>
+        </div>
+        <div className="weather-card__meta">
+          <p>{description}</p>
+          <p>Wind: {windspeed.toFixed(1)} km/h</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+WeatherCard.propTypes = {
+  locationLabel: PropTypes.string.isRequired,
+  weather: PropTypes.shape({
+    temperature: PropTypes.number.isRequired,
+    windspeed: PropTypes.number.isRequired,
+    weathercode: PropTypes.number.isRequired,
+    time: PropTypes.string.isRequired,
+  }).isRequired,
+};
+
+export default WeatherCard;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './App.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- bootstrap a Vite + React project for the weather application
- add a geolocation-aware experience that fetches current conditions from Open-Meteo with a city search fallback
- style the interface with responsive cards and provide project documentation and linting configuration

## Testing
- npm install *(fails: registry access returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc754affd08323bbe9985338638681